### PR TITLE
Fullwidth guide

### DIFF
--- a/commons/src/main/scala/io/udash/web/commons/views/ImageFactory.scala
+++ b/commons/src/main/scala/io/udash/web/commons/views/ImageFactory.scala
@@ -2,7 +2,6 @@ package io.udash.web.commons.views
 
 import org.scalajs.dom
 import org.scalajs.dom.raw.Element
-
 import scalatags.JsDom
 import scalatags.JsDom.all._
 import scalatags.generic.Namespace
@@ -16,7 +15,7 @@ object ImageFactoryPrefixSet {
 
 object ClickableImageFactory {
   def apply(prefix: ImageFactoryPrefix, name: String, altText: String, xs: Modifier*): JsDom.TypedTag[dom.html.Anchor] =
-    a(href := "/" + prefix.value + "/" + name, target := "_blank", xs)(
+    a(href := prefix.value + "/" + name, target := "_blank", rel := "external", xs)(
       (new ImageFactory(prefix.value))(name, altText)
     )
 }

--- a/shared/src/main/scala/io/udash/web/commons/styles/GlobalStyles.scala
+++ b/shared/src/main/scala/io/udash/web/commons/styles/GlobalStyles.scala
@@ -28,7 +28,7 @@ object GlobalStyles extends CssBase {
 
   val body = style(
     position.relative,
-    width(StyleConstants.Sizes.BodyWidth px),
+    padding(StyleConstants.Sizes.BodyPaddingPx px),
     height(100 %%),
     margin(0 px, auto),
 

--- a/shared/src/main/scala/io/udash/web/commons/styles/utils/StyleConstants.scala
+++ b/shared/src/main/scala/io/udash/web/commons/styles/utils/StyleConstants.scala
@@ -9,7 +9,7 @@ object StyleConstants extends CssBase {
     * SIZES
     */
   object Sizes {
-    val BodyWidth = 1075
+    val BodyPaddingPx = 30
     val MinSiteHeight = 550
     val LandingPageHeaderHeight = 150
     val HeaderHeight = 80
@@ -39,7 +39,7 @@ object StyleConstants extends CssBase {
     * MEDIA QUERIES
     */
   object MediaQueriesBounds {
-    val TabletLandscapeMax = Sizes.BodyWidth - 1
+    val TabletLandscapeMax = 1074
     val TabletLandscapeMin = 768
     val TabletMax = TabletLandscapeMin - 1
     val TabletMin = 481

--- a/shared/src/main/scala/io/udash/web/guide/styles/partials/GuideStyles.scala
+++ b/shared/src/main/scala/io/udash/web/guide/styles/partials/GuideStyles.scala
@@ -18,27 +18,6 @@ object GuideStyles extends CssBase with CodeBlockStyles {
     minHeight :=! s"calc(100vh - ${StyleConstants.Sizes.HeaderHeight}px - ${StyleConstants.Sizes.FooterHeight}px)"
   )
 
-  val imgSmall = style(
-    GuideStyleUtils.border(),
-    maxWidth(40 %%),
-    maxHeight(200 px),
-    padding(1.5 rem),
-    margin(`0`, 2 rem, 2 rem, 2 rem)
-  )
-
-  val imgMedium = style(
-    GuideStyleUtils.border(),
-    maxWidth(70 %%),
-    maxHeight(350 px),
-    padding(1.5 rem),
-    margin(`0`, 2 rem, 2 rem, 2 rem)
-  )
-
-  val imgBig = style(
-    maxWidth(100 %%),
-    maxHeight(750 px)
-  )
-
   val floatLeft = style(float.left)
   val floatRight = style(
     float.right
@@ -203,6 +182,31 @@ object GuideStyles extends CssBase with CodeBlockStyles {
     display.block,
     padding(1.5 rem),
     margin(2 rem, `0`)
+  )
+
+  val imgSmall = style(
+    display.table,
+    GuideStyleUtils.border(),
+    maxWidth(40 %%),
+    maxHeight(200 px),
+    padding(1.5 rem),
+    margin(`0`, 2 rem, 2 rem, 2 rem),
+    display.table
+  )
+
+  val imgMedium = style(
+    display.table,
+    GuideStyleUtils.border(),
+    maxWidth(70 %%),
+    maxHeight(350 px),
+    padding(1.5 rem),
+    margin(`0`, 2 rem, 2 rem, 2 rem)
+  )
+
+  val imgBig = style(
+    display.table,
+    maxWidth(100 %%),
+    maxHeight(750 px)
   )
 
   val useBootstrap = style(


### PR DESCRIPTION
- full-width guide on desktop, get rid of the empty bars on both sides of guide
- fix image styles for full-widh guide and image links for `WindowPathUrlChangeProvider`
